### PR TITLE
Don't cache this plugin

### DIFF
--- a/cmsplugin_forms_builder/cms_plugins.py
+++ b/cmsplugin_forms_builder/cms_plugins.py
@@ -12,6 +12,7 @@ class FormBuilderPlugin(CMSPluginBase):
     model = PluginForm
     name = _("Form")
     render_template = "forms/form_detail.html"
+    cache = False
 
     def render(self, context, instance, placeholder):
         context['form'] = instance.form


### PR DESCRIPTION
When this plugin is used in conjunction with full-page caching, the csrf token gets cached, causing authentication issues.  This fix should stop this behaviour from happening.