### PR TITLE
Improving UI for plugin widget

### DIFF
--- a/cmsplugin_forms_builder/cms_plugins.py
+++ b/cmsplugin_forms_builder/cms_plugins.py
@@ -9,6 +9,7 @@ class FormBuilderPlugin(CMSPluginBase):
         Plugin class for form-builder forms.
     """
 
+    module = _("Forms")
     model = PluginForm
     name = _("Form")
     render_template = "forms/form_detail.html"

--- a/cmsplugin_forms_builder/models.py
+++ b/cmsplugin_forms_builder/models.py
@@ -9,3 +9,6 @@ class PluginForm(CMSPlugin):
     """
 
     form = models.ForeignKey(Form)
+
+    def __str__(self):
+        return self.form.title


### PR DESCRIPTION
`models.PluginForm.__str__()` will make it prettier for the end user, as `form.title` is required.
Before:
![screenshot from 2018-01-17 14-59-47](https://user-images.githubusercontent.com/2727048/35047367-ffd34432-fb99-11e7-912e-72b861c61f7a.png)
After:
![screenshot from 2018-01-17 14-59-02](https://user-images.githubusercontent.com/2727048/35047370-01f85c52-fb9a-11e7-9b59-bf3b38aa4271.png)

----

`cms_plugins.FormBuilderPlugin.module` will add a meaningful header in the plugin list.
Before:
![screen shot 2018-01-17 at 14 02 20](https://user-images.githubusercontent.com/2727048/35047294-bf4748b4-fb99-11e7-93c0-08eb124e5445.png)
After:
![screen shot 2018-01-17 at 14 02 00](https://user-images.githubusercontent.com/2727048/35047300-c345b8ce-fb99-11e7-851e-72d445d75f1c.png)
